### PR TITLE
Added some extra highlighting

### DIFF
--- a/simpc-mode.el
+++ b/simpc-mode.el
@@ -44,9 +44,9 @@
 
 (defun simpc-font-lock-keywords ()
   (list
+   `("# *\\(warn\\|error\\)" . font-lock-warning-face)
    `("# *[#a-zA-Z0-9_]+" . font-lock-preprocessor-face)
    `("# *include\\(?:_next\\)?\\s-+\\(\\(<\\|\"\\).*\\(>\\|\"\\)\\)" . (1 font-lock-string-face))
-   `("# *\\(warn\\|error\\)" . font-lock-warning-face)
    `("\\(?:enum\\|struct\\)\\s-+\\([a-zA-Z0-9_]+\\)" . (1 font-lock-type-face))
    `(,(regexp-opt (simpc-keywords) 'symbols) . font-lock-keyword-face)
    `(,(regexp-opt (simpc-types) 'symbols) . font-lock-type-face)))


### PR DESCRIPTION
Highlighting: Added `va_list` as a type, corrected `include` preprocessor directive, added `warn` and `error` preprocessor directive highlighting, added highlighting `NULL` and, finally, added highlighting for struct and enum names (`struct|enum (NAME)`)

I've tested this with the amalgamated sqlite file, the speed after the modification didn't change noticeably.