### PR TITLE
Fix: update auto-mode-alist regex to support .cc files

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,8 +26,8 @@ Put [simpc-mode.el](./simpc-mode.el) to some folder `/path/to/simpc/`. Add this 
 (add-to-list 'load-path "/path/to/simpc/")
 ;; Importing simpc-mode
 (require 'simpc-mode)
-;; Automatically enabling simpc-mode on files with extensions like .h, .c, .cpp, .hpp
-(add-to-list 'auto-mode-alist '("\\.[hc]\\(pp\\)?\\'" . simpc-mode))
+;; Automatically enabling simpc-mode on files with extensions like .h, .c, .cpp, .hpp, .cc
+(add-to-list 'auto-mode-alist '("\\.[ch]\\(pp\\|c\\)?\\'" . simpc-mode))
 ```
 
 ## Indentation


### PR DESCRIPTION
Description:
Updated the auto-mode-alist regex in the README to correctly match .cc file extensions.
Changes:
Changed \\.[hc]\\(pp\\)?\\' to \\.[ch]\\(pp\\|c\\)?\\'
This ensures that files ending in .cc (common in Google-style C++ projects) are automatically opened in simpc-mode.