### PR TITLE
Makes simpc-mode work with more real C/C++ projects.

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,8 +26,9 @@ Put [simpc-mode.el](./simpc-mode.el) to some folder `/path/to/simpc/`. Add this 
 (add-to-list 'load-path "/path/to/simpc/")
 ;; Importing simpc-mode
 (require 'simpc-mode)
-;; Automatically enabling simpc-mode on files with extensions like .h, .c, .cpp, .hpp
-(add-to-list 'auto-mode-alist '("\\.[hc]\\(pp\\)?\\'" . simpc-mode))
+;; Automatically enabling simpc-mode on files with extensions like .h, .c, .cpp, .hpp ...
+(dolist (ext '(".c" ".h" ".C" ".H" ".cc" ".hh" ".cpp"  ".hpp" ".cxx" ".hxx"))
+  (add-to-list 'auto-mode-alist (cons (concat "\\" ext "\\'") 'simpc-mode)))
 ```
 
 ## Indentation


### PR DESCRIPTION
changes:
- switches from a regex to a clear list of extensions
- adds common C/C++ extensions (.C/.H, .cc/.hh, .cxx/.hxx) 