### PR TITLE
feat: add 'ptrdiff_t' type found in stddef.h

### DIFF
--- a/simpc-mode.el
+++ b/simpc-mode.el
@@ -24,7 +24,7 @@
     "char16_t" "char32_t" "char8_t"
     "int8_t" "uint8_t" "int16_t" "uint16_t" "int32_t" "uint32_t" "int64_t" "uint64_t"
     "uintptr_t"
-    "size_t"
+    "size_t" "ptrdiff_t"
     "va_list"))
 
 (defun simpc-keywords ()


### PR DESCRIPTION
Hi,
this PR add to the type list the type `ptrdiff_t`, witch is a signed `size_t`, made to do pointer arithmetic. This type is defined in the `<stddef.h>` header.