### PR TITLE
fix word delimiting with + and -

### DIFF
--- a/simpc-mode.el
+++ b/simpc-mode.el
@@ -17,6 +17,10 @@
 
     (modify-syntax-entry ?& "." table)
     (modify-syntax-entry ?% "." table)
+
+    (modify-syntax-entry ?+ "." table)
+    (modify-syntax-entry ?- "." table)
+
     table))
 
 (defun simpc-types ()


### PR DESCRIPTION
symbol-based actions will include `+`, `-`, `++` and `--` operators as part of the word unless there is whitespace.

Up to you if this is intentional or not.